### PR TITLE
Add simple frontend and filterable backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ npm start
 
 The server will run on port `3001` by default. You can override the port by setting the `PORT` variable in a `.env` file. To stop the server press `Ctrl+C` in the terminal where it is running.
 
+## Frontend
+
+A minimal frontend is provided in the `webapp` folder. After starting the backend, open `webapp/index.html` in a web browser to view the list of incidences. You can filter results by priority or facility and limit the number of rows returned.
+
+The backend endpoint `/incidencias` now accepts the following query parameters:
+
+- `limit` (default `1000`)
+- `offset`
+- `priority`
+- `facility`
+
+These parameters can be combined to paginate and filter the results.
+
 ## Notes
 
 The previous Windows batch files (`start-app.bat` and `stop-app.bat`) have been removed. Use the `npm` commands above to run the backend on any operating system.

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Incidences</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Incidence List</h1>
+  <div>
+    <label>Priority: <input id="priority" type="text"></label>
+    <label>Facility: <input id="facility" type="text"></label>
+    <label>Limit: <input id="limit" type="number" value="1000"></label>
+    <button id="load">Load</button>
+  </div>
+  <table id="incidences"></table>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/webapp/script.js
+++ b/webapp/script.js
@@ -1,0 +1,48 @@
+document.getElementById('load').addEventListener('click', fetchData);
+
+function fetchData() {
+  const priority = document.getElementById('priority').value;
+  const facility = document.getElementById('facility').value;
+  const limit = document.getElementById('limit').value || 1000;
+
+  const params = new URLSearchParams();
+  if (priority) params.append('priority', priority);
+  if (facility) params.append('facility', facility);
+  if (limit) params.append('limit', limit);
+
+  fetch(`http://localhost:3001/incidencias?${params.toString()}`)
+    .then(res => res.json())
+    .then(showData)
+    .catch(err => {
+      console.error(err);
+      alert('Error fetching incidences');
+    });
+}
+
+function showData(data) {
+  const table = document.getElementById('incidences');
+  table.innerHTML = '';
+  if (!Array.isArray(data) || data.length === 0) {
+    table.innerHTML = '<tr><td>No results</td></tr>';
+    return;
+  }
+
+  const headers = Object.keys(data[0]);
+  const headerRow = document.createElement('tr');
+  headers.forEach(h => {
+    const th = document.createElement('th');
+    th.textContent = h;
+    headerRow.appendChild(th);
+  });
+  table.appendChild(headerRow);
+
+  data.forEach(item => {
+    const row = document.createElement('tr');
+    headers.forEach(h => {
+      const td = document.createElement('td');
+      td.textContent = item[h];
+      row.appendChild(td);
+    });
+    table.appendChild(row);
+  });
+}


### PR DESCRIPTION
## Summary
- add filtering and pagination to `/incidencias`
- provide a tiny frontend in `webapp` for browsing incidences
- document the new frontend and query parameters

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686cc3146d84833180be95ebdcd2bced