### PR TITLE
Fix Angular example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ The server will run on port `3001` by default. You can override the port by sett
 Two example frontends are included:
 
 1. `webapp` contains the original plain JavaScript version.
-2. `frontend` contains a lightweight Angular application. Open `frontend/index.html` in a browser after running `npx tsc -p frontend/tsconfig.json` to compile the TypeScript sources. The Angular version provides the same filters and table display as the plain JavaScript one.
+2. `frontend` contains a lightweight Angular application. Install its dependencies and run the build script:
+   ```bash
+   cd frontend
+   npm install
+   npm run build
+   ```
+   Then open `frontend/index.html` in a browser. The Angular version provides the same filters and table display as the plain JavaScript one.
 
 The backend endpoint `/incidencias` now accepts the following query parameters:
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,10 @@
 </head>
 <body>
   <incidence-app></incidence-app>
+  <!-- Zone.js is required because the compiled Angular code contains a bare
+       import for 'zone.js'. When this page is served without a bundler the
+       browser needs the library explicitly loaded. -->
+  <script src="https://cdn.jsdelivr.net/npm/zone.js@0.15.1/bundles/zone.umd.min.js"></script>
   <script type="module" src="./dist/main.js"></script>
 </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "dependencies": {
     "@angular/common": "^20.0.6",
     "@angular/core": "^20.0.6",


### PR DESCRIPTION
## Summary
- add build instructions for Angular app
- include zone.js from CDN so index.html works standalone
- add `build` script in Angular package.json

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686cd5fdaad48331bd15f75db0933803