### PR TITLE
Add simple web frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,11 @@ The server will run on port `3001` by default. You can override the port by sett
 
 ## Frontend
 
-Two example frontends are included:
+An example frontend is included in the `webapp` folder. It is a small
+plain JavaScript application that lists the incidences returned by the
+backend and lets you edit each record.
 
-1. `webapp` contains the original plain JavaScript version.
-2. `frontend` contains a lightweight Angular application. Install its dependencies and run the build script:
-   ```bash
-   cd frontend
-   npm install
-   npm run build
-   ```
-   Then open `frontend/index.html` in a browser. The Angular version provides the same filters and table display as the plain JavaScript one.
+After starting the backend simply open `webapp/index.html` in a browser.
 
 The backend endpoint `/incidencias` now accepts the following query parameters:
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Incidence Editor</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <h1>Incidence Editor</h1>
+
+    <section id="filters">
+        <label>
+            Priority:
+            <input type="text" id="filter-priority" placeholder="e.g. High">
+        </label>
+        <label>
+            Facility:
+            <input type="text" id="filter-facility" placeholder="Facility name">
+        </label>
+        <label>
+            Limit:
+            <input type="number" id="filter-limit" value="100" min="1">
+        </label>
+        <button id="apply-filters">Apply Filters</button>
+    </section>
+
+    <table id="incidences-table">
+        <thead>
+            <tr>
+                <th>Id</th>
+                <th>Manager</th>
+                <th>Worker Code</th>
+                <th>Facility</th>
+                <th>Description</th>
+                <th>Incidence Date</th>
+                <th>Priority</th>
+                <th>Actions</th>
+                <th>Action Operator</th>
+                <th>Resolution Date</th>
+                <th>Stop Init</th>
+                <th>Stop End</th>
+                <th>Notified To</th>
+                <th>Assigned To</th>
+                <th>Created</th>
+                <th>Last Modified</th>
+                <th>Archived</th>
+                <th>Edit</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <section id="edit-section" class="hidden">
+        <h2>Edit Incidence</h2>
+        <form id="edit-form">
+            <input type="hidden" id="edit-id">
+            <div class="form-grid">
+                <label>Manager Name<input type="text" id="edit-ManagerName"></label>
+                <label>Worker Code<input type="text" id="edit-WorkerCode"></label>
+                <label>Facility<input type="text" id="edit-Facility"></label>
+                <label>Description<input type="text" id="edit-Description"></label>
+                <label>Incidence Date<input type="datetime-local" id="edit-IncidenceDate"></label>
+                <label>Priority<input type="text" id="edit-Priority"></label>
+                <label>Actions<input type="text" id="edit-Actions"></label>
+                <label>Action Operator<input type="text" id="edit-ActionOperator"></label>
+                <label>Resolution Date<input type="datetime-local" id="edit-ResolutionDate"></label>
+                <label>Stop Init<input type="datetime-local" id="edit-StopInit"></label>
+                <label>Stop End<input type="datetime-local" id="edit-StopEnd"></label>
+                <label>Notified To<input type="text" id="edit-NotifiedTo"></label>
+                <label>Assigned To<input type="text" id="edit-AssignedTo"></label>
+                <label>Archived<input type="checkbox" id="edit-Archived"></label>
+            </div>
+            <button type="submit">Save</button>
+            <button type="button" id="cancel-edit">Cancel</button>
+        </form>
+    </section>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/webapp/script.js
+++ b/webapp/script.js
@@ -1,0 +1,100 @@
+const API_BASE = 'http://localhost:3001';
+
+async function fetchIncidences() {
+    const priority = document.getElementById('filter-priority').value;
+    const facility = document.getElementById('filter-facility').value;
+    const limit = document.getElementById('filter-limit').value || 100;
+
+    const params = new URLSearchParams({ limit });
+    if (priority) params.append('priority', priority);
+    if (facility) params.append('facility', facility);
+
+    const response = await fetch(`${API_BASE}/incidencias?${params.toString()}`);
+    const incidences = await response.json();
+    renderTable(incidences);
+}
+
+function renderTable(incidences) {
+    const tbody = document.querySelector('#incidences-table tbody');
+    tbody.innerHTML = '';
+
+    incidences.forEach(inc => {
+        const tr = document.createElement('tr');
+        for (const key of [
+            'Id','ManagerName','WorkerCode','Facility','Description',
+            'IncidenceDate','Priority','Actions','ActionOperator','ResolutionDate',
+            'StopInit','StopEnd','NotifiedTo','AssignedTo','CreatedDate','LastModifiedDate','Archived'
+        ]) {
+            const td = document.createElement('td');
+            td.textContent = inc[key];
+            tr.appendChild(td);
+        }
+
+        const editTd = document.createElement('td');
+        const btn = document.createElement('button');
+        btn.textContent = 'Edit';
+        btn.addEventListener('click', () => openEditForm(inc));
+        editTd.appendChild(btn);
+        tr.appendChild(editTd);
+
+        tbody.appendChild(tr);
+    });
+}
+
+function openEditForm(inc) {
+    const section = document.getElementById('edit-section');
+    section.classList.remove('hidden');
+    document.getElementById('edit-id').value = inc.Id;
+    const fields = [
+        'ManagerName','WorkerCode','Facility','Description','IncidenceDate',
+        'Priority','Actions','ActionOperator','ResolutionDate','StopInit',
+        'StopEnd','NotifiedTo','AssignedTo','Archived'
+    ];
+    fields.forEach(f => {
+        const el = document.getElementById(`edit-${f}`);
+        if (el.type === 'checkbox') {
+            el.checked = inc[f];
+        } else {
+            el.value = inc[f] || '';
+        }
+    });
+}
+
+function closeEditForm() {
+    document.getElementById('edit-section').classList.add('hidden');
+}
+
+document.getElementById('apply-filters').addEventListener('click', fetchIncidences);
+document.getElementById('cancel-edit').addEventListener('click', closeEditForm);
+document.getElementById('edit-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const id = document.getElementById('edit-id').value;
+    const data = {
+        ManagerName: document.getElementById('edit-ManagerName').value,
+        WorkerCode: document.getElementById('edit-WorkerCode').value,
+        Facility: document.getElementById('edit-Facility').value,
+        Description: document.getElementById('edit-Description').value,
+        IncidenceDate: document.getElementById('edit-IncidenceDate').value,
+        Priority: document.getElementById('edit-Priority').value,
+        Actions: document.getElementById('edit-Actions').value,
+        ActionOperator: document.getElementById('edit-ActionOperator').value,
+        ResolutionDate: document.getElementById('edit-ResolutionDate').value,
+        StopInit: document.getElementById('edit-StopInit').value,
+        StopEnd: document.getElementById('edit-StopEnd').value,
+        NotifiedTo: document.getElementById('edit-NotifiedTo').value,
+        AssignedTo: document.getElementById('edit-AssignedTo').value,
+        Archived: document.getElementById('edit-Archived').checked
+    };
+
+    await fetch(`${API_BASE}/incidencias/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+    });
+
+    closeEditForm();
+    fetchIncidences();
+});
+
+// Initial load
+fetchIncidences();

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -1,0 +1,37 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+#filters {
+    margin-bottom: 20px;
+}
+
+#filters label {
+    margin-right: 10px;
+}
+
+#incidences-table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+#incidences-table th,
+#incidences-table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+}
+
+#incidences-table th {
+    background-color: #f2f2f2;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 10px;
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- include a new `webapp` frontend with HTML, JS and CSS
- allow filtering and editing incidences through the backend API
- update README to describe the new frontend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686cdba4d1848331b6d304d8555b9af5