### PR TITLE
Add ID filter improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ The backend endpoint `/incidencias` now accepts the following query parameters:
 - `offset`
 - `priority`
 - `facility`
+- `id`
 
 These parameters can be combined to paginate and filter the results.
+When `id` is provided the backend returns only the matching incidence
+and ignores any `offset` value.
 
 ## Notes
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,11 +13,25 @@ const PORT = process.env.PORT || 3001;
 // GET - Lista de incidencias (sin imágenes)
 app.get('/incidencias', async (req, res) => {
   try {
-    const { limit = 1000, offset = 0, priority, facility } = req.query;
+    const {
+      limit = 1000,
+      offset = 0,
+      priority,
+      facility,
+      id: idParam,
+    } = req.query;
+
+    const id = idParam ? parseInt(idParam, 10) : undefined;
+    const limitNum = parseInt(limit, 10) || 1000;
+    const offsetNum = parseInt(offset, 10) || 0;
 
     const filters = [];
     const values = [];
 
+    if (id) {
+      values.push(id);
+      filters.push(`"Id" = $${values.length}`);
+    }
     if (priority) {
       values.push(priority);
       filters.push(`"Priority" = $${values.length}`);
@@ -40,11 +54,12 @@ app.get('/incidencias', async (req, res) => {
     }
 
     query += ' ORDER BY "Id"';
-    values.push(limit);
+    const finalLimit = id ? 1 : limitNum;
+    values.push(finalLimit);
     query += ` LIMIT $${values.length}`;
 
-    if (offset) {
-      values.push(offset);
+    if (!id && offsetNum) {
+      values.push(offsetNum);
       query += ` OFFSET $${values.length}`;
     }
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -17,6 +17,10 @@
 
     <section id="filters">
         <label>
+            Id:
+            <input type="number" id="filter-id" placeholder="e.g. 123">
+        </label>
+        <label>
             Priority:
             <input type="text" id="filter-priority" placeholder="e.g. High">
         </label>

--- a/webapp/script.js
+++ b/webapp/script.js
@@ -4,11 +4,14 @@ async function fetchIncidences() {
 
     hideMessage();
 
+    const idValue = document.getElementById('filter-id').value;
+    const id = idValue ? parseInt(idValue, 10) : null;
     const priority = document.getElementById('filter-priority').value;
     const facility = document.getElementById('filter-facility').value;
     const limit = document.getElementById('filter-limit').value || 100;
 
     const params = new URLSearchParams({ limit });
+    if (id) params.append('id', id);
     if (priority) params.append('priority', priority);
     if (facility) params.append('facility', facility);
 


### PR DESCRIPTION
## Summary
- parse query params as numbers in the backend
- force limit=1 when an `id` query is provided
- document `id` filter behaviour
- parse the ID input as a number in the frontend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ce41fdd14833191298deb6e3dce93